### PR TITLE
Formula

### DIFF
--- a/ros/src/styx/bridge.py
+++ b/ros/src/styx/bridge.py
@@ -49,7 +49,7 @@ class Bridge(object):
             '/vehicle/steering_cmd': self.callback_steering,
             '/vehicle/throttle_cmd': self.callback_throttle,
             '/vehicle/brake_cmd': self.callback_brake,
-        '/final_waypoints': self.callback_path
+            '/final_waypoints': self.callback_path
         }
 
         self.subscribers = [rospy.Subscriber(e.topic, TYPE[e.type], self.callbacks[e.topic])

--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -77,6 +77,8 @@ private:
   geometry_msgs::TwistStamped current_velocity_;
   WayPoints current_waypoints_;
 
+  geometry_msgs::TwistStamped target_velocity_;
+
   double getCmdVelocity(int waypoint) const;
   void calcLookaheadDistance(int waypoint);
   double calcCurvature(geometry_msgs::Point target) const;
@@ -115,6 +117,8 @@ public:
   void callbackFromCurrentPose(const geometry_msgs::PoseStampedConstPtr &msg);
   void callbackFromCurrentVelocity(const geometry_msgs::TwistStampedConstPtr &msg);
   void callbackFromWayPoints(const styx_msgs::LaneConstPtr &msg);
+
+  void callbackFromTargetVelocity(const geometry_msgs::TwistStampedConstPtr &msg);
 
   // for debug
   geometry_msgs::Point getPoseOfNextWaypoint() const

--- a/ros/src/waypoint_follower/src/pure_pursuit.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit.cpp
@@ -62,6 +62,10 @@ int main(int argc, char **argv)
   ros::Subscriber est_twist_subscriber =
       nh.subscribe("current_velocity", 10, &waypoint_follower::PurePursuit::callbackFromCurrentVelocity, &pp);
 
+  ros::Subscriber target_vel_subscriber =
+      nh.subscribe("target_velocity", 10, &waypoint_follower::PurePursuit::callbackFromTargetVelocity, &pp);
+
+
   ROS_INFO("pure pursuit start");
   ros::Rate loop_rate(LOOP_RATE);
   while (ros::ok())

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -47,6 +47,11 @@ void PurePursuit::callbackFromCurrentVelocity(const geometry_msgs::TwistStampedC
   velocity_set_ = true;
 }
 
+void PurePursuit::callbackFromTargetVelocity(const geometry_msgs::TwistStampedConstPtr &msg)
+{
+  target_velocity_ = *msg;
+}
+
 void PurePursuit::callbackFromWayPoints(const styx_msgs::LaneConstPtr &msg)
 {
   current_waypoints_.setPath(*msg);
@@ -62,7 +67,10 @@ double PurePursuit::getCmdVelocity(int waypoint) const
     return 0;
   }
 
-  double velocity = current_waypoints_.getWaypointVelocityMPS(waypoint);
+  // double velocity = current_waypoints_.getWaypointVelocityMPS(waypoint);
+
+  double velocity = target_velocity_.twist.linear.x;
+
   // ROS_INFO_STREAM("waypoint : " << mps2kmph(velocity) << " km/h ( " << velocity << "m/s )");
   return velocity;
 }

--- a/ros/src/waypoint_loader/launch/waypoint_loader.launch
+++ b/ros/src/waypoint_loader/launch/waypoint_loader.launch
@@ -3,6 +3,6 @@
     <node pkg="waypoint_loader" type="waypoint_loader.py" name="waypoint_loader">
     	<param name="path" value="$(find styx)../../../data/wp_yaw_const.csv"/>
         <!-- <param name="path" value="$(find styx)../../../data/churchlot_with_cars.csv"/>  -->
-        <param name="velocity" value="80.4672" /> <!-- value in km/h: 80.4672 km/h = 50 mph -->
+        <param name="velocity" value="60" /> <!-- value in km/h: 80.4672 km/h = 50 mph -->
     </node>
 </launch>

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -42,7 +42,7 @@ class WaypointUpdater(object):
         self.target_vel_pub = rospy.Publisher('/target_velocity', TwistStamped, queue_size=1)
 
         # test publisher for debugging
-        self.test = rospy.Publisher('/test', String, queue_size=1)
+        #self.test = rospy.Publisher('/test', String, queue_size=1)
 
         # object variables
         self.pose = None

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -106,7 +106,7 @@ class WaypointUpdater(object):
         tw = TwistStamped()
         lane = Lane()
 
-        self.test.publish(str(self.dbw_status))
+        #self.test.publish(str(self.dbw_status))
 
         if self.dbw_status == False:
             self.acceleration_status = 0


### PR DESCRIPTION
changes the way how the target speed is given to the /pure_pursuit node which ultimately leads to a cleaner /twist_cmd, especially at lower speeds and without the need for additional interpolation.
Instead of attaching the velocity to the waypoints in topic /final_waypoints the target speed can now be directly calculated via formulas and is then published to a new topic called /target_speed. The node /pure_pursuit subscribes to that topic and takes this value as the basic command velocity.